### PR TITLE
remove console.log

### DIFF
--- a/src/Jimdo/JimFlow/PrintTicketBundle/Resources/public/js/print-form/templates.js
+++ b/src/Jimdo/JimFlow/PrintTicketBundle/Resources/public/js/print-form/templates.js
@@ -11,8 +11,6 @@ $(function () {
         },
         before:function ($container, $button) {
             var self = this;
-
-            console.log($button);
             $container.addClass('inactive');
             $button.addClass('chosen');
             $statusElm.removeClass('fail ok').addClass('loading');


### PR DESCRIPTION
Just stumbled over that `console.log` when I was printing a ticket.
